### PR TITLE
Sslprofile support for lbvserver and csvserver

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -95,7 +95,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:8a340d9c7d3192e3148f03868b6b8471756597a6d8c8421d1c089c5196905784"
+  digest = "1:39e062e2a4d43fb87911a049bc0a6014b1b0b4ab24bcaa3b0b13036caead6c52"
   name = "github.com/chiradeep/go-nitro"
   packages = [
     "config/basic",
@@ -108,7 +108,7 @@
     "netscaler",
   ]
   pruneopts = ""
-  revision = "1c6319d70e8d62054b6f5a8624254bd335eda0c3"
+  revision = "dc93fece3b47b128b55ff7a2665a38b91afebe3b"
 
 [[projects]]
   digest = "1:56c130d885a4aacae1dd9c7b71cfe39912c7ebc1ff7d2b46083c8812996dc43b"
@@ -313,11 +313,11 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:38c88e6e5564d7dd92360b432e841a41749f6f1985bbae325e56d2aa1a4dd143"
+  digest = "1:0db944d08f7a506ee635f0ca7d133d1f5fbc773750dc3325030688f8f6c0e681"
   name = "github.com/hashicorp/yamux"
   packages = ["."]
   pruneopts = ""
-  revision = "2658be15c5f05e76244154714161f17e3e77de2e"
+  revision = "7221087c3d281fda5f794e28c2ea4c6e4d5c4558"
 
 [[projects]]
   digest = "1:6f49eae0c1e5dab1dafafee34b207aeb7a42303105960944828c2079b92fc88e"

--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ resource "netscaler_lbvserver" "foo" {
   lbmethod = "ROUNDROBIN"
   persistencetype = "COOKIEINSERT"
   sslcertkey = "${netscaler_sslcertkey.foo.certkey}"
+  sslprofile = "ns_default_ssl_profile_secure_frontend"
 }
 ```
 
@@ -129,6 +130,7 @@ resource "netscaler_csvserver" "foo" {
   ipv46 = "10.71.139.151"
   servicetype = "SSL"
   port = 443
+  sslprofile = "ns_default_ssl_profile_secure_frontend"
 }
 ```
 

--- a/examples/content_switch_ssl_lb_mon/resources.tf
+++ b/examples/content_switch_ssl_lb_mon/resources.tf
@@ -13,6 +13,7 @@ resource "netscaler_csvserver" "generic_cs" {
   port = "${lookup(var.lb_config, "port")}"
   servicetype = "${lookup(var.lb_config, "servicetype")}"
   sslcertkey = "${netscaler_sslcertkey.generic-cert.certkey}"
+  sslprofile = "ns_default_ssl_profile_secure_frontend"
 }
 
 resource "netscaler_cspolicy" "cart" {

--- a/examples/ssl_lb_monitors/resources.tf
+++ b/examples/ssl_lb_monitors/resources.tf
@@ -15,6 +15,7 @@ resource "netscaler_lbvserver" "generic_lb" {
   persistencetype = "COOKIEINSERT"
   servicetype = "${lookup(var.lb_config, "servicetype")}"
   sslcertkey = "${netscaler_sslcertkey.generic-cert.certkey}"
+  sslprofile = "ns_default_ssl_profile_secure_frontend"
 }
 
 

--- a/vendor/github.com/chiradeep/go-nitro/config/ssl/sslvserver.go
+++ b/vendor/github.com/chiradeep/go-nitro/config/ssl/sslvserver.go
@@ -37,4 +37,5 @@ type Sslvserver struct {
 	Tls11               string `json:"tls11,omitempty"`
 	Tls12               string `json:"tls12,omitempty"`
 	Vservername         string `json:"vservername,omitempty"`
+	Sslprofile          string `json:"sslprofile,omitempty"`
 }

--- a/vendor/github.com/chiradeep/go-nitro/jsonconfig/ssl/sslvserver.json
+++ b/vendor/github.com/chiradeep/go-nitro/jsonconfig/ssl/sslvserver.json
@@ -136,6 +136,9 @@
     },
     "vservername" : {
       "type" : "string"
+    },
+    "sslprofile" : {
+      "type" : "string"
     }
   },
   "$schema" : "http://json-schema.org/draft-04/schema#",

--- a/vendor/github.com/chiradeep/go-nitro/netscaler/client.go
+++ b/vendor/github.com/chiradeep/go-nitro/netscaler/client.go
@@ -39,6 +39,7 @@ type NitroParams struct {
 //It abstracts the REST operations of the NITRO API
 type NitroClient struct {
 	url       string
+	statsURL  string
 	username  string
 	password  string
 	proxiedNs string
@@ -51,6 +52,7 @@ type NitroClient struct {
 func NewNitroClient(url string, username string, password string) *NitroClient {
 	c := new(NitroClient)
 	c.url = strings.Trim(url, " /") + "/nitro/v1/config/"
+	c.statsURL = strings.Trim(url, " /") + "/nitro/v1/stat/"
 	c.username = username
 	c.password = password
 	c.client = &http.Client{}
@@ -68,6 +70,7 @@ func NewNitroClientFromParams(params NitroParams) (*NitroClient, error) {
 	}
 	c := new(NitroClient)
 	c.url = strings.Trim(params.Url, " /") + "/nitro/v1/config/"
+	c.statsURL = strings.Trim(params.Url, " /") + "/nitro/v1/stat/"
 	c.username = params.Username
 	c.password = params.Password
 	c.proxiedNs = params.ProxiedNs

--- a/vendor/github.com/chiradeep/go-nitro/netscaler/config_test.go
+++ b/vendor/github.com/chiradeep/go-nitro/netscaler/config_test.go
@@ -22,11 +22,12 @@ import (
 	"testing"
 	"time"
 
+	"os"
+
 	"github.com/chiradeep/go-nitro/config/basic"
 	"github.com/chiradeep/go-nitro/config/lb"
 	"github.com/chiradeep/go-nitro/config/network"
 	"github.com/chiradeep/go-nitro/config/ns"
-	"os"
 )
 
 var client *NitroClient

--- a/vendor/github.com/chiradeep/go-nitro/netscaler/netscaler_resource.go
+++ b/vendor/github.com/chiradeep/go-nitro/netscaler/netscaler_resource.go
@@ -349,3 +349,16 @@ func (c *NitroClient) clearConfig(clearJSON []byte) error {
 	_, err := c.doHTTPRequest("POST", url, bytes.NewBuffer(clearJSON), createResponseHandler)
 	return err
 }
+
+func (c *NitroClient) listStat(resourceType, resourceName string) ([]byte, error) {
+	log.Println("[DEBUG] go-nitro: listing resource of type ", resourceType, ", name: ", resourceName)
+	url := c.statsURL + resourceType
+
+	if resourceName != "" {
+		url = c.statsURL + fmt.Sprintf("%s/%s", resourceType, resourceName)
+	}
+	log.Println("[TRACE] go-nitro: url is ", url)
+
+	return c.doHTTPRequest("GET", url, bytes.NewBuffer([]byte{}), readResponseHandler)
+
+}

--- a/vendor/github.com/chiradeep/go-nitro/netscaler/stats.go
+++ b/vendor/github.com/chiradeep/go-nitro/netscaler/stats.go
@@ -1,0 +1,54 @@
+package netscaler
+
+import (
+	"log"
+	"fmt"
+	"encoding/json"
+)
+
+//FindStats returns the statistics of the supplied resource type if it exists. Use when the resource to be returned is an array
+func (c *NitroClient) FindAllStats(resourceType string) ([]map[string]interface{}, error) {
+	var data map[string]interface{}
+	result, err := c.listStat(resourceType, "")
+	if err != nil {
+		log.Printf("[WARN] go-nitro: FindStats: No %s found", resourceType)
+		return nil, fmt.Errorf("[INFO] go-nitro: FindStats: No type %s found", resourceType)
+	}
+	if err = json.Unmarshal(result, &data); err != nil {
+		log.Printf("[ERROR] go-nitro: FindStats: Failed to unmarshal Netscaler Response!")
+		return nil, fmt.Errorf("[ERROR] go-nitro: FindStats: Failed to unmarshal Netscaler Response: type %s", resourceType)
+	}
+	rsrcs, ok := data[resourceType]
+	if !ok || rsrcs == nil {
+		log.Printf("[WARN] go-nitro: FindStats No %s type found", resourceType)
+		return nil, fmt.Errorf("[INFO] go-nitro: FindStats: No type of %s found", resourceType)
+	}
+	resources := data[resourceType].([]interface{})
+	ret := make([]map[string]interface{}, len(resources), len(resources))
+	for i, v := range resources {
+		ret[i] = v.(map[string]interface{})
+	}
+	return ret, nil
+}
+
+//FindStat returns the config of the supplied resource name and type if it exists
+func (c *NitroClient) FindStat(resourceType string, resourceName string) (map[string]interface{}, error) {
+	var data map[string]interface{}
+	result, err := c.listStat(resourceType, resourceName)
+	if err != nil {
+		log.Printf("[WARN] go-nitro: FindStat: No %s %s found", resourceType, resourceName)
+		return nil, fmt.Errorf("[INFO] go-nitro: FindStat: No resource %s of type %s found", resourceName, resourceType)
+	}
+	if err = json.Unmarshal(result, &data); err != nil {
+		log.Printf("[ERROR] go-nitro: FindStat: Failed to unmarshal Netscaler Response!")
+		return nil, fmt.Errorf("[ERROR] go-nitro: FindStat: Failed to unmarshal Netscaler Response:resource %s of type %s", resourceName, resourceType)
+	}
+	rsrc, ok := data[resourceType]
+	if !ok || rsrc == nil {
+		log.Printf("[WARN] go-nitro: FindStat No %s type with name %s found", resourceType, resourceName)
+		return nil, fmt.Errorf("[INFO] go-nitro: FindStat: No resource %s of type %s found", resourceName, resourceType)
+	}
+	resource := data[resourceType].([]interface{})[0] //only one resource obviously
+
+	return resource.(map[string]interface{}), nil
+}

--- a/vendor/github.com/chiradeep/go-nitro/netscaler/stats_test.go
+++ b/vendor/github.com/chiradeep/go-nitro/netscaler/stats_test.go
@@ -1,0 +1,105 @@
+package netscaler
+
+import (
+	"log"
+	"testing"
+
+	"github.com/chiradeep/go-nitro/config/basic"
+	"github.com/chiradeep/go-nitro/config/lb"
+)
+
+func TestNitroClient_FindAllStats(t *testing.T) {
+	lbName1 := "test_lb_" + randomString(5)
+	lbName2 := "test_lb_" + randomString(5)
+	lb1 := lb.Lbvserver{
+		Name:        lbName1,
+		Ipv46:       randomIP(),
+		Lbmethod:    "ROUNDROBIN",
+		Servicetype: "HTTP",
+		Port:        8000,
+	}
+	lb2 := lb.Lbvserver{
+		Name:        lbName2,
+		Ipv46:       randomIP(),
+		Lbmethod:    "LEASTCONNECTION",
+		Servicetype: "HTTP",
+		Port:        8000,
+	}
+	_, err := client.AddResource(Lbvserver.Type(), lbName1, &lb1)
+	if err != nil {
+		t.Error("Failed to add resource of type ", Lbvserver.Type(), ":", lbName1)
+		log.Println("Cannot continue")
+		return
+	}
+	_, err = client.AddResource(Lbvserver.Type(), lbName2, &lb2)
+	if err != nil {
+		t.Error("Failed to add resource of type ", Lbvserver.Type(), ":", lbName2)
+		log.Println("Cannot continue")
+		return
+	}
+	_, err = client.FindAllStats(Lbvserver.Type())
+	if err != nil {
+		t.Error("Did not find statistics of type ", err, Lbvserver.Type())
+	}
+}
+
+func TestNitroClient_FindStats(t *testing.T) {
+	lbName1 := "test_lb_" + randomString(5)
+	lb1 := lb.Lbvserver{
+		Name:        lbName1,
+		Ipv46:       randomIP(),
+		Lbmethod:    "ROUNDROBIN",
+		Servicetype: "HTTP",
+		Port:        8000,
+	}
+
+	_, err := client.AddResource(Lbvserver.Type(), lbName1, &lb1)
+	if err != nil {
+		t.Error("Failed to add resource of type ", Lbvserver.Type(), ":", lbName1)
+		log.Println("Cannot continue")
+		return
+	}
+
+	svcName1 := "test_svc_" + randomString(5)
+	svcName2 := "test_svc_" + randomString(5)
+	service1 := basic.Service{
+		Name:        svcName1,
+		Ip:          randomIP(),
+		Port:        80,
+		Servicetype: "HTTP",
+	}
+	service2 := basic.Service{
+		Name:        svcName2,
+		Ip:          randomIP(),
+		Port:        80,
+		Servicetype: "HTTP",
+	}
+
+	_, err = client.AddResource(Service.Type(), svcName1, &service1)
+	if err != nil {
+		t.Error("Could not create service service1", err)
+		log.Println("Cannot continue")
+		return
+	}
+	_, err = client.AddResource(Service.Type(), svcName2, &service2)
+	if err != nil {
+		t.Error("Could not create service service2", err)
+		log.Println("Cannot continue")
+		return
+	}
+	for _, resourceType := range []string{Lbvserver.Type(), Service.Type(), Gslbvserver.Type(), Gslbservice.Type()} {
+		rsrc, err := client.FindAllResources(resourceType)
+		if err != nil {
+			// Ignore the erratic resource type
+			continue
+		}
+		for _, availableItem := range rsrc {
+			_, err = client.FindStat(resourceType, availableItem["name"].(string))
+			if err != nil {
+				t.Fatal(err)
+			}
+			// only check one
+			break
+		}
+	}
+}

--- a/vendor/github.com/hashicorp/yamux/go.mod
+++ b/vendor/github.com/hashicorp/yamux/go.mod
@@ -1,0 +1,1 @@
+module github.com/hashicorp/yamux

--- a/vendor/github.com/hashicorp/yamux/mux.go
+++ b/vendor/github.com/hashicorp/yamux/mux.go
@@ -3,6 +3,7 @@ package yamux
 import (
 	"fmt"
 	"io"
+	"log"
 	"os"
 	"time"
 )
@@ -30,8 +31,13 @@ type Config struct {
 	// window size that we allow for a stream.
 	MaxStreamWindowSize uint32
 
-	// LogOutput is used to control the log destination
+	// LogOutput is used to control the log destination. Either Logger or
+	// LogOutput can be set, not both.
 	LogOutput io.Writer
+
+	// Logger is used to pass in the logger to be used. Either Logger or
+	// LogOutput can be set, not both.
+	Logger *log.Logger
 }
 
 // DefaultConfig is used to return a default configuration
@@ -56,6 +62,11 @@ func VerifyConfig(config *Config) error {
 	}
 	if config.MaxStreamWindowSize < initialStreamWindow {
 		return fmt.Errorf("MaxStreamWindowSize must be larger than %d", initialStreamWindow)
+	}
+	if config.LogOutput != nil && config.Logger != nil {
+		return fmt.Errorf("both Logger and LogOutput may not be set, select one")
+	} else if config.LogOutput == nil && config.Logger == nil {
+		return fmt.Errorf("one of Logger or LogOutput must be set, select one")
 	}
 	return nil
 }


### PR DESCRIPTION
Added sslprofile support for lbvserver and csvserver.
Included [ns_default_ssl_profile_secure_frontend](https://docs.citrix.com/en-us/netscaler/12-1/ssl/ssl-profiles/secure-front-end-profile.html) sslprofile to examples.

Tested scenarios with both resource types:
[x] Set sslprofile
[x] Unset sslprofile
[x] Change sslprofile to another

Closes #13 